### PR TITLE
RPM: Persist /var/run/quagga

### DIFF
--- a/quagga.rpm.mk
+++ b/quagga.rpm.mk
@@ -15,6 +15,7 @@ clean:
 build: quagga-$(VERSION).tar.gz redhat/quagga.spec
 	for d in SOURCES SPECS; do mkdir -p $(RPMBUILD)/$$d; done
 	cp -afv quagga-$(VERSION).tar.gz $(RPMBUILD)/SOURCES
+	cp -afv redhat/quagga-tmpfs.conf $(RPMBUILD)/SOURCES
 	cp -afv redhat/quagga.spec $(RPMBUILD)/SPECS
 	rpmbuild -bb --clean $(RPMBUILD)/SPECS/quagga.spec \
 	    --define '_topdir $(abspath $(RPMBUILD))'

--- a/redhat/quagga-tmpfs.conf
+++ b/redhat/quagga-tmpfs.conf
@@ -1,0 +1,1 @@
+d	/var/run/quagga	0755 quagga quagga

--- a/redhat/quagga.spec.in
+++ b/redhat/quagga.spec.in
@@ -117,6 +117,7 @@ Release:	%{?commit_date}%{?commit}
 License:	GPL
 Group: System Environment/Daemons
 Source0:	http://downloads.pf.itd.nrl.navy.mil/ospf-manet/%{srcname}-%{version}.tar.gz
+Source2:	quagga-tmpfs.conf
 URL:		http://www.nrl.navy.mil/itd/ncs/products/ospf-manet
 %if %{with_snmp}
 BuildRequires:	net-snmp-devel
@@ -286,6 +287,8 @@ install -m644 %{zeb_rh_src}/quagga.logrotate \
 install -m644 %{zeb_rh_src}/quagga.sysconfig \
 	$RPM_BUILD_ROOT/etc/sysconfig/quagga
 install -d -m750  $RPM_BUILD_ROOT/var/run/quagga
+install -d -m 755 %{buildroot}/%{_tmpfilesdir}
+install -p -m 644 %{SOURCE2} %{buildroot}/%{_tmpfilesdir}/quagga.conf
 
 %pre
 # add vty_group
@@ -471,6 +474,7 @@ rm -rf $RPM_BUILD_ROOT
 %config /etc/quagga/[!v]*
 %config /etc/rc.d/init.d/*
 %config(noreplace) /etc/sysconfig/quagga
+%{_tmpfilesdir}/quagga.conf
 %if %{with_pam}
 %config(noreplace) /etc/pam.d/quagga
 %endif


### PR DESCRIPTION
On EL7 and newer, /var/run/quagga is a tmpfs that goes away on reboots.

The current package creates this directory, but on reboot the directory
is gone so the services fail to start. There is a systemd facility
to create files and directories at boot time.

This commit copies the upstream CentOS7 tmpfiles config file,
quagga-tmpfs.conf:
https://git.centos.org/rpms/quagga/blob/c7/f/SOURCES/quagga-tmpfs.conf
and the necessary SPEC lines to install it from the upstream spec:
https://git.centos.org/rpms/quagga/blob/c7/f/SPECS/quagga.spec