### PR TITLE
Added missing extern

### DIFF
--- a/lib/built.h
+++ b/lib/built.h
@@ -1,6 +1,6 @@
 #ifndef _ZEBRA_BUILT_H
 #define _ZEBRA_BUILT_H
 
-const char *quagga_built_string;
+extern const char *quagga_built_string;
 
 #endif  /* _ZEBRA_BUILT_H */


### PR DESCRIPTION
This fixes a "multiple definition" error across various build artefacts when linking