### PR TITLE
xpimd: Rename macro static_assert() to x_static_assert()

### DIFF
--- a/xpimd/xorp/libproto/packet.hh
+++ b/xpimd/xorp/libproto/packet.hh
@@ -392,11 +392,11 @@ public:
 	  _ip_src(_data + _ip_src_offset),
 	  _ip_dst(_data + _ip_dst_offset)
     {
-	static_assert(IpHeader4::SIZE == _ip_vhl_sizeof + _ip_tos_sizeof
-		      + _ip_len_sizeof + _ip_id_sizeof + _ip_off_sizeof
-		      + _ip_ttl_sizeof + _ip_p_sizeof + _ip_sum_sizeof
-		      + _ip_src_sizeof + _ip_dst_sizeof);
-	static_assert(IpHeader4::SIZE == _ip_dst_offset + _ip_dst_sizeof);
+	x_static_assert(IpHeader4::SIZE == _ip_vhl_sizeof + _ip_tos_sizeof
+			+ _ip_len_sizeof + _ip_id_sizeof + _ip_off_sizeof
+			+ _ip_ttl_sizeof + _ip_p_sizeof + _ip_sum_sizeof
+			+ _ip_src_sizeof + _ip_dst_sizeof);
+	x_static_assert(IpHeader4::SIZE == _ip_dst_offset + _ip_dst_sizeof);
     }
 
     static const size_t SIZE = 20;		// The header size
@@ -681,10 +681,10 @@ public:
 	  _ip_src(_data + _ip_src_offset),
 	  _ip_dst(_data + _ip_dst_offset)
     {
-	static_assert(IpHeader6::SIZE == _ip_vtc_flow_sizeof
-		      + _ip_plen_sizeof + _ip_nxt_sizeof + _ip_hlim_sizeof
-		      + _ip_src_sizeof + _ip_dst_sizeof);
-	static_assert(IpHeader6::SIZE == _ip_dst_offset + _ip_dst_sizeof);
+	x_static_assert(IpHeader6::SIZE == _ip_vtc_flow_sizeof
+			+ _ip_plen_sizeof + _ip_nxt_sizeof + _ip_hlim_sizeof
+			+ _ip_src_sizeof + _ip_dst_sizeof);
+	x_static_assert(IpHeader6::SIZE == _ip_dst_offset + _ip_dst_sizeof);
     }
 
     static const size_t SIZE = 40;		// The header size

--- a/xpimd/xorp/libxorp/ipv4.hh
+++ b/xpimd/xorp/libxorp/ipv4.hh
@@ -468,7 +468,7 @@ public:
      * @return address size in number of octets.
      */
     inline static size_t addr_bytelen() {
-	static_assert(sizeof(IPv4) == sizeof(uint32_t));
+	x_static_assert(sizeof(IPv4) == sizeof(uint32_t));
 	return sizeof(IPv4);
     }
 

--- a/xpimd/xorp/libxorp/ipv6.cc
+++ b/xpimd/xorp/libxorp/ipv6.cc
@@ -186,7 +186,7 @@ IPv6
 IPv6::operator<<(uint32_t ls) const
 {
     uint32_t tmp_addr[4];
-    static_assert(sizeof(_addr) == sizeof(tmp_addr));
+    x_static_assert(sizeof(_addr) == sizeof(tmp_addr));
 
     // Shift the words, and at the same time convert them into host-order
     switch (ls / 32) {
@@ -241,7 +241,7 @@ IPv6
 IPv6::operator>>(uint32_t rs) const
 {
     uint32_t tmp_addr[4];
-    static_assert(sizeof(_addr) == sizeof(tmp_addr));
+    x_static_assert(sizeof(_addr) == sizeof(tmp_addr));
 
     // Shift the words, and at the same time convert them into host-order
     switch (rs / 32) {
@@ -296,7 +296,7 @@ bool
 IPv6::operator<(const IPv6& other) const
 {
     int i;
-    static_assert(sizeof(_addr) == 16);
+    x_static_assert(sizeof(_addr) == 16);
 
     for (i = 0; i < 3; i++) {	// XXX: Loop ends intentionally at 3 not 4
 	if (_addr[i] != other._addr[i])

--- a/xpimd/xorp/libxorp/ipv6.hh
+++ b/xpimd/xorp/libxorp/ipv6.hh
@@ -422,7 +422,7 @@ public:
      * @return address size in number of octets.
      */
     inline static size_t addr_bytelen() {
-	static_assert(sizeof(IPv6) == 4 * sizeof(uint32_t));
+	x_static_assert(sizeof(IPv6) == 4 * sizeof(uint32_t));
 	return sizeof(IPv6);
     }
 

--- a/xpimd/xorp/libxorp/ipvx.cc
+++ b/xpimd/xorp/libxorp/ipvx.cc
@@ -57,8 +57,8 @@ IPvX::IPvX(int family, const uint8_t *from_uint8) throw (InvalidFamily)
 
 IPvX::IPvX(const IPv4& ipv4)
 {
-    static_assert(sizeof(_addr) >= sizeof(IPv4));
-    static_assert(sizeof(IPv4) == 4);
+    x_static_assert(sizeof(_addr) >= sizeof(IPv4));
+    x_static_assert(sizeof(IPv4) == 4);
 
     _af = AF_INET;
     memset(_addr, 0, sizeof(_addr));
@@ -67,8 +67,8 @@ IPvX::IPvX(const IPv4& ipv4)
 
 IPvX::IPvX(const IPv6& ipv6)
 {
-    static_assert(sizeof(_addr) >= sizeof(IPv6));
-    static_assert(sizeof(IPv6) == 16);
+    x_static_assert(sizeof(_addr) >= sizeof(IPv6));
+    x_static_assert(sizeof(IPv6) == 16);
 
     _af = AF_INET6;
     memcpy(_addr, &ipv6, 16);
@@ -181,7 +181,7 @@ IPvX::operator>>(uint32_t right_shift) const
 bool
 IPvX::operator<(const IPvX& other) const
 {
-    static_assert(sizeof(_addr) == 16);
+    x_static_assert(sizeof(_addr) == 16);
     unsigned int i;
 
     // Loop ends intentionally at the next-to-last word, not the last word.

--- a/xpimd/xorp/libxorp/selector.cc
+++ b/xpimd/xorp/libxorp/selector.cc
@@ -179,8 +179,8 @@ SelectorList::Node::is_empty()
 SelectorList::SelectorList(ClockBase *clock)
     : _clock(clock), _observer(NULL), _maxfd(0), _descriptor_count(0)
 {
-    static_assert(SEL_RD == (1 << SEL_RD_IDX) && SEL_WR == (1 << SEL_WR_IDX)
-		  && SEL_EX == (1 << SEL_EX_IDX) && SEL_MAX_IDX == 3);
+    x_static_assert(SEL_RD == (1 << SEL_RD_IDX) && SEL_WR == (1 << SEL_WR_IDX)
+		    && SEL_EX == (1 << SEL_EX_IDX) && SEL_MAX_IDX == 3);
     for (int i = 0; i < SEL_MAX_IDX; i++)
 	FD_ZERO(&_fds[i]);
 }

--- a/xpimd/xorp/libxorp/selector.hh
+++ b/xpimd/xorp/libxorp/selector.hh
@@ -228,7 +228,7 @@ private:
 private:
     enum {
 	// correspond to SelectorMask; correspondence checked with
-	// static_assert
+	// x_static_assert
 	SEL_RD_IDX	= 0,
 	SEL_WR_IDX	= 1,
 	SEL_EX_IDX	= 2,

--- a/xpimd/xorp/libxorp/utility.h
+++ b/xpimd/xorp/libxorp/utility.h
@@ -24,10 +24,10 @@
 /*
  * Compile time assertion.
  */
-#ifndef static_assert
+#ifndef x_static_assert
 // +0 is to work around clang bug.
-#define static_assert(a) switch ((a) + 0) case 0: case ((a) + 0):
-#endif /* static_assert */
+#define x_static_assert(a) switch ((a) + 0) case 0: case ((a) + 0):
+#endif /* x_static_assert */
 
 /*
  * A macro to avoid compilation warnings about unused functions arguments.
@@ -37,7 +37,7 @@
 #ifdef UNUSED
 # undef UNUSED
 #endif /* UNUSED */
-#define UNUSED(var)	static_assert(sizeof(var) != 0)
+#define UNUSED(var)	x_static_assert(sizeof(var) != 0)
 
 #ifdef __cplusplus
 #define cstring(s) (s).str().c_str()


### PR DESCRIPTION
This avoids a conflict with the C++11 declaration by the same name.

Extracted from: https://github.com/greearb/xorp.ct/commit/45f5520c