### PR TITLE
vtysh: Limit files in xpimd/ processed by `extract.pl`

### DIFF
--- a/vtysh/Makefile.am
+++ b/vtysh/Makefile.am
@@ -25,7 +25,7 @@ vtysh_cmd_FILES = $(top_srcdir)/bgpd/*.c $(top_srcdir)/isisd/*.c \
 		  $(top_srcdir)/ospfd/*.c $(top_srcdir)/ospf6d/*.c \
 		  $(top_srcdir)/ripd/*.c $(top_srcdir)/ripngd/*.c \
 		  $(top_srcdir)/babeld/*.c \
-		  $(top_srcdir)/xpimd/*.cc \
+		  $(top_srcdir)/xpimd/zebra_*_command.cc \
 		  $(top_srcdir)/lib/keychain.c $(top_srcdir)/lib/routemap.c \
 		  $(top_srcdir)/lib/filter.c $(top_srcdir)/lib/plist.c \
 		  $(top_srcdir)/lib/distribute.c $(top_srcdir)/lib/if_rmap.c \


### PR DESCRIPTION
During the build, the script `vtysh/extract.pl` identifies the supported VTY commands and their structure, by using the source code itself. To do this, the script directly calls the C/C++ preprocessor on individual files, and then it parses the output.

This fails when examining certain files in xpimd/: the preprocessor is not called with the flags needed to locate all the header files they include. However, those files do not define VTY commands and can be ignored here.

Resolve this by limiting the files in xpimd/ that are read by this script.